### PR TITLE
Multiple requests are now combined into one PDF file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+#Ipython Notebook
+.ipynb_checkpoints

--- a/getyourdata/data_request/services.py
+++ b/getyourdata/data_request/services.py
@@ -22,6 +22,9 @@ def concatenate_pdf_pages(pdf_pages):
     """
     Concatenate multiple PDF pages into one PDF document
     """
+    if len(pdf_pages) == 1:
+        return pdf_pages[0]
+        
     try:
         merger = PdfFileMerger()
 

--- a/getyourdata/data_request/services.py
+++ b/getyourdata/data_request/services.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 
 from xhtml2pdf import pisa
+from PyPDF2 import PdfFileMerger
 
 from StringIO import StringIO
+
 
 def convert_html_to_pdf(html_data):
     """
@@ -14,3 +16,21 @@ def convert_html_to_pdf(html_data):
     pisa.CreatePDF(StringIO(html_data), pdf)
 
     return pdf.getvalue()
+
+
+def concatenate_pdf_pages(pdf_pages):
+    """
+    Concatenate multiple PDF pages into one PDF document
+    """
+    try:
+        merger = PdfFileMerger()
+
+        for pdf_page in pdf_pages:
+            merger.append(StringIO(pdf_page))
+
+        complete_pdf = StringIO()
+        merger.write(complete_pdf)
+
+        return complete_pdf.getvalue()
+    except:
+        return False

--- a/getyourdata/data_request/templates/data_request/request_data.html
+++ b/getyourdata/data_request/templates/data_request/request_data.html
@@ -7,10 +7,15 @@
     <div class="row">
         <div class="col-md-12">
             <div class="page-header">
-                <h1>{% trans 'Request your data from' %} {{ organization.name }}</h1>
+                {% if organizations|length == 1 %}
+                <h1>{% trans 'Request your data from' %} {{ organizations.0.name }}</h1>
+                {% else %}
+                <h1>{% trans 'Request your data from multiple organizations' %}</h1>
+                {% endif %}
             </div>
-            <form class="form-horizontal" method="post" action="{% url 'data_request:request_data' organization.id %}">
+            <form class="form-horizontal" method="post" action="{% url 'data_request:request_data' %}">
                 {% csrf_token %}
+                <input type="hidden" name="org_ids" value="{{ org_ids}}"/>
                 <table class="table">
                 {% bootstrap_form form layout='horizontal' %}
                 </table>

--- a/getyourdata/data_request/tests.py
+++ b/getyourdata/data_request/tests.py
@@ -55,6 +55,17 @@ class DataRequestCreationTests(TestCase):
         self.assertContains(response, "Other thing")
         self.assertContains(response, "Request your data from Organization")
 
+    def test_data_request_form_with_multiple_organizations_is_correct(self):
+        response = self.client.get(
+            reverse("data_request:request_data",
+                    args=("%d,%d" % (self.organization.id,
+                                     self.organization2.id),)))
+
+        self.assertContains(response, "Some number")
+        self.assertContains(response, "Other thing")
+        self.assertContains(response, "Oddest thing")
+        self.assertContains(response, "Request your data from multiple organizations")
+
     def test_data_request_is_created(self):
         self.client.post(
             reverse("data_request:request_data", args=(self.organization.id,)),

--- a/getyourdata/data_request/tests.py
+++ b/getyourdata/data_request/tests.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from data_request.models import DataRequest, AuthenticationContent
 from organization.models import Organization, AuthenticationField
 
+
 class DataRequestCreationTests(TestCase):
     def setUp(self):
         self.organization = Organization.objects.create(
@@ -14,19 +15,35 @@ class DataRequestCreationTests(TestCase):
             postal_code='00000',
             country='Finland'
             )
+        self.organization2 = Organization.objects.create(
+            name='Organization Two',
+            email_address='fake@addressa.com',
+            address_line_one='Address 2',
+            address_line_two='Address 4',
+            postal_code='012345',
+            country='Sweden'
+            )
+
         self.auth_field1 = AuthenticationField.objects.create(
             name="some_number",
             title='Some number')
         self.auth_field2 = AuthenticationField.objects.create(
             name='other_thing',
             title="Other thing")
+        self.auth_field3 = AuthenticationField.objects.create(
+            name='oddest_thing',
+            title="Oddest thing")
 
         self.assertEquals(self.organization.authentication_fields.all().count(), 0)
 
         self.organization.authentication_fields.add(self.auth_field1)
         self.organization.authentication_fields.add(self.auth_field2)
 
+        self.organization2.authentication_fields.add(self.auth_field2)
+        self.organization2.authentication_fields.add(self.auth_field3)
+
         self.assertEquals(self.organization.authentication_fields.all().count(), 2)
+        self.assertEquals(self.organization2.authentication_fields.all().count(), 2)
         self.assertEquals(DataRequest.objects.all().count(), 0)
         self.assertEquals(AuthenticationContent.objects.all().count(), 0)
 
@@ -51,6 +68,24 @@ class DataRequestCreationTests(TestCase):
         data_request = DataRequest.objects.first()
 
         self.assertTrue(data_request.organization == self.organization)
+
+    def test_multiple_data_requests_can_be_created(self):
+        self.client.post(
+            reverse("data_request:request_data",
+                    args=("%d,%d" % (self.organization.id,
+                                     self.organization2.id),)),
+            {"some_number": "1234567",
+             "other_thing": "Some text here",
+             "oddest_thing": "blehbleh"},
+            follow=True)
+
+        self.assertEquals(DataRequest.objects.all().count(), 2)
+
+        data_request1 = DataRequest.objects.get(organization=self.organization)
+        data_request2 = DataRequest.objects.get(organization=self.organization2)
+
+        self.assertEquals(data_request1.organization, self.organization)
+        self.assertEquals(data_request2.organization, self.organization2)
 
     def test_authentication_contents_are_created(self):
         self.client.post(

--- a/getyourdata/data_request/urls.py
+++ b/getyourdata/data_request/urls.py
@@ -4,5 +4,6 @@ from data_request import views as data_request_views
 
 
 urlpatterns = [
-    url(r'^new/(?P<organization_id>\d+)$', data_request_views.request_data, name='request_data'),
+    url(r'^new/(?P<org_ids>[\w,]+)$', data_request_views.request_data, name='request_data'),
+    url(r'^new/$', data_request_views.request_data, name='request_data'),
 ]

--- a/getyourdata/data_request/urls.py
+++ b/getyourdata/data_request/urls.py
@@ -5,5 +5,6 @@ from data_request import views as data_request_views
 
 urlpatterns = [
     url(r'^new/(?P<org_ids>[\w,]+)$', data_request_views.request_data, name='request_data'),
+    # List of organization IDs can also be passed as a POST parameter
     url(r'^new/$', data_request_views.request_data, name='request_data'),
 ]

--- a/getyourdata/data_request/views.py
+++ b/getyourdata/data_request/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import ugettext as _
 
@@ -8,50 +8,75 @@ from data_request.forms import DataRequestForm
 from data_request.models import DataRequest, AuthenticationContent
 from organization.models import Organization
 
-def request_data(request, organization_id):
-    organization = get_object_or_404(Organization, pk=organization_id)
+from data_request.services import concatenate_pdf_pages
+
+
+def request_data(request, org_ids=None):
+    if org_ids is None:
+        org_ids = request.POST.get("org_ids", None)
+
+    if not org_ids:
+        return HttpResponse(
+            _("No organization ID or organization ID list was provided!"),
+            status=400)
+
+    organizations = Organization.objects.filter(id__in=org_ids.split(","))
 
     if request.method == 'POST':
-        form = DataRequestForm(request.POST, organization=organization)
+        form = DataRequestForm(request.POST, organizations=organizations)
 
         if form.is_valid():
-            data_request = DataRequest.objects.create(organization=organization)
-            auth_fields = organization.authentication_fields.all()
-            auth_contents = []
+            pdf_pages = []
 
-            for auth_field in auth_fields:
-                auth_contents.append(AuthenticationContent(
-                    auth_field=auth_field,
-                    data_request=data_request,
-                    content=form.cleaned_data[auth_field.name]
-                    ))
-            AuthenticationContent.objects.bulk_create(auth_contents)
+            for organization in organizations:
+                data_request = DataRequest.objects.create(organization=organization)
+                auth_fields = organization.authentication_fields.all()
+                auth_contents = []
 
-            # TODO: Create PDF and send email to organization.
-            # Note that there will be no reason to save AuthenticationContents in our database.
-            # We are doing it here now just for illustration purposes.
-            '''
-            messages.success(
-                request, _('Your data was successfully requested from %s!'
-                % organization.name))
-            '''
-            pdf_data = data_request.to_pdf()
+                for auth_field in auth_fields:
+                    auth_contents.append(AuthenticationContent(
+                        auth_field=auth_field,
+                        data_request=data_request,
+                        content=form.cleaned_data[auth_field.name]
+                        ))
+                AuthenticationContent.objects.bulk_create(auth_contents)
 
-            if not pdf_data:
-                messages.error(
-                    request, _("The PDF file couldn't be created! Please try again later."))
-                return render(request, 'data_request/request_data.html', {
-                    'form': form,
-                    'organization': organization,
-                })
+                # TODO: Create PDF and send email to organization.
+                # Note that there will be no reason to save AuthenticationContents in our database.
+                # We are doing it here now just for illustration purposes.
+                '''
+                messages.success(
+                    request, _('Your data was successfully requested from %s!'
+                    % organization.name))
+                '''
+                pdf_page = data_request.to_pdf()
+
+                if not pdf_page:
+                    messages.error(
+                        request, _("The PDF file couldn't be created! Please try again later."))
+                    return render(request, 'data_request/request_data.html', {
+                        'form': form,
+                        'organizations': organizations,
+                        'org_ids': org_ids,
+                    })
+
+                pdf_pages.append(pdf_page)
+
+            if len(pdf_pages) == 1:
+                pdf_data = pdf_pages[0]
             else:
-                response = HttpResponse(pdf_data, content_type='application/pdf')
-                response["Content-Disposition"] = 'attachment; filename="request.pdf"'
-                return response
+                # If we have more than one PDF request, we need to concatenate
+                # all requests into one PDF file
+                pdf_data = concatenate_pdf_pages(pdf_pages)
+
+            response = HttpResponse(pdf_data, content_type='application/pdf')
+            response["Content-Disposition"] = 'attachment; filename="request.pdf"'
+            return response
     else:
-        form = DataRequestForm(organization=organization)
-        
+        form = DataRequestForm(organizations=organizations)
+
     return render(request, 'data_request/request_data.html', {
         'form': form,
-        'organization': organization,
+        'organizations': organizations,
+        'org_ids': org_ids,
     })

--- a/getyourdata/data_request/views.py
+++ b/getyourdata/data_request/views.py
@@ -62,12 +62,7 @@ def request_data(request, org_ids=None):
 
                 pdf_pages.append(pdf_page)
 
-            if len(pdf_pages) == 1:
-                pdf_data = pdf_pages[0]
-            else:
-                # If we have more than one PDF request, we need to concatenate
-                # all requests into one PDF file
-                pdf_data = concatenate_pdf_pages(pdf_pages)
+            pdf_data = concatenate_pdf_pages(pdf_pages)
 
             response = HttpResponse(pdf_data, content_type='application/pdf')
             response["Content-Disposition"] = 'attachment; filename="request.pdf"'


### PR DESCRIPTION
Multiple requests can now be created at once; the resulting PDF pages are concatenated into one PDF file.

Multiple requests can be done in two ways: use a comma-separated list of organization IDs in the url eg. /new/4,5,6,9 or pass the same list as the POST parameter 'org_ids'. 
