### PR TITLE
Make data requests memory-only

### DIFF
--- a/getyourdata/data_request/tests.py
+++ b/getyourdata/data_request/tests.py
@@ -4,7 +4,6 @@ from django.test import TestCase
 from data_request.models import DataRequest, AuthenticationContent
 from organization.models import Organization, AuthenticationField
 
-
 class DataRequestCreationTests(TestCase):
     def setUp(self):
         self.organization = Organization.objects.create(

--- a/getyourdata/getyourdata/settings.py
+++ b/getyourdata/getyourdata/settings.py
@@ -25,6 +25,11 @@ SECRET_KEY = '9n2k6si$nzvbrl*k(0!*x@n#(m#@rx1jd_x4q0+e1uip7!$=t#'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
+# Are we running tests
+TESTING = False
+
+TEST_RUNNER = "getyourdata.testrunner.TestSuiteRunner"
+
 ALLOWED_HOSTS = []
 
 

--- a/getyourdata/getyourdata/testrunner.py
+++ b/getyourdata/getyourdata/testrunner.py
@@ -1,0 +1,10 @@
+from django.test.runner import DiscoverRunner
+
+from django.conf import settings
+
+class TestSuiteRunner(DiscoverRunner):
+    def setup_test_environment(self, *args, **kwargs):
+        # Not an ideal solution; maybe the relevant methods
+        # should be mocked instead
+        settings.TESTING = True
+        super(TestSuiteRunner, self).setup_test_environment(*args, **kwargs)

--- a/getyourdata/getyourdata/util.py
+++ b/getyourdata/getyourdata/util.py
@@ -1,0 +1,25 @@
+"""A few utility methods that disable and enable transactions
+
+They are used to keep saved requests for the duration of the test
+so that they can be inspected
+
+These methods should probably be mocked instead of relying on a setting value
+"""
+
+from django.db import transaction
+from django.conf import settings
+
+
+def set_autocommit_on():
+    if not settings.TESTING:
+        transaction.set_autocommit(True)
+
+
+def rollback():
+    if not settings.TESTING:
+        transaction.rollback()
+
+
+def set_autocommit_off():
+    if not settings.TESTING:
+        transaction.set_autocommit(False)


### PR DESCRIPTION
Data requests are now handled inside transactions, which are simply rolled back when the request PDF has been generated.

The unit tests still allow data to persist for a single test case so that the generated entries can be inspected.
