### PR TITLE
Add 'back' button to requests. Streamline request creation steps.

### DIFF
--- a/getyourdata/data_request/models.py
+++ b/getyourdata/data_request/models.py
@@ -79,6 +79,24 @@ class DataRequest(BaseModel):
                                                "pdfcontent": pdfcontent,
                                                "current_datetime": timezone.now()})
 
+    def to_plain_text(self):
+        """
+        Return data request as plain text that would be used in the PDF document
+        """
+        try:
+            person_name = self.auth_contents.get(auth_field__name="name")
+        except:
+            person_name = None
+
+        pdfcontent, created = PdfContents.objects.get_or_create(title="Default")
+        return render_to_string(
+            "data_request/mail_plain/request.html",
+            {"data_request": self,
+             "person_name": person_name,
+             "pdfcontent": pdfcontent,
+             "current_datetime": timezone.now()})
+
+
     def to_email_body(self):
         """
         Return data request as the text used in the email request
@@ -91,6 +109,7 @@ class DataRequest(BaseModel):
                 "email_content": email_content
             }
         )
+
 
     def to_pdf(self):
         """

--- a/getyourdata/data_request/templates/data_request/mail_plain/request.html
+++ b/getyourdata/data_request/templates/data_request/mail_plain/request.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{{ data_request.organization.name }}
+{{ data_request.organization.address_line_one }}
+{{ data_request.organization.address_line_two }}
+{{ data_request.organization.postal_code }}
+{{ data_request.organization.country }}
+
+{{ current_datetime }}
+
+{{ pdfcontent.header }}
+
+{{ pdfcontent.content1 }}
+{{ pdfcontent.content2 }}
+
+{% for auth_content in data_request.auth_contents.all %}
+{{ auth_content.auth_field }}: {{ auth_content.content }}
+{% endfor %}
+
+{% if person_name %}
+{{ pdfcontent.footer }}
+{{ person_name.content }}
+{% endif %}

--- a/getyourdata/data_request/templates/data_request/request_data.html
+++ b/getyourdata/data_request/templates/data_request/request_data.html
@@ -25,7 +25,7 @@
                 {% bootstrap_form form layout='horizontal' %}
                 </table>
                 <input class="btn btn-primary" type="button" onclick="window.history.back()" value="{% trans 'Back' %}">
-                <input class="btn btn-default" id="create_request" type="submit" value="{% trans 'Review request' %}"/>
+                <input class="btn btn-success" id="create_request" type="submit" value="{% trans 'Review request' %}"/>
             </form>
         </div>
         <div class="col-md-4">

--- a/getyourdata/data_request/templates/data_request/request_data.html
+++ b/getyourdata/data_request/templates/data_request/request_data.html
@@ -20,11 +20,12 @@
             <form class="form-horizontal" method="post" action="{% url 'data_request:request_data' %}">
                 {% csrf_token %}
                 <input type="hidden" name="org_ids" value="{{ org_ids }}"/>
-                <input type="hidden" name="action" value="{% if email_organizations|length == 0 %}send{% else %}review{% endif %}"/>
+                <input type="hidden" name="action" value="review"/>
                 <table class="table">
                 {% bootstrap_form form layout='horizontal' %}
                 </table>
-                <input class="btn btn-default" id="create_request" type="submit" value="{% if email_organizations|length == 0 %}{% trans 'Create request' %}{% else %}{% trans 'Review request' %}{% endif %}"/>
+                <input class="btn btn-primary" type="button" onclick="window.history.back()" value="{% trans 'Back' %}">
+                <input class="btn btn-default" id="create_request" type="submit" value="{% trans 'Review request' %}"/>
             </form>
         </div>
         <div class="col-md-4">

--- a/getyourdata/data_request/templates/data_request/request_data_review.html
+++ b/getyourdata/data_request/templates/data_request/request_data_review.html
@@ -18,28 +18,47 @@
                 <input type="hidden" name="org_ids" value="{{ org_ids }}"/>
                 <input type="hidden" name="action" value="send"/>
                 <div class="form-group">
-                    <label class="control-label" for="select-email">{% trans "Please review the following email messages" %}</label>
+                    <label class="control-label" for="select-email">
+                        {% blocktrans count counter=data_requests|length trimmed %}
+                        Please review the following message
+                        {% plural %}
+                        Please review the following messages
+                        {% endblocktrans %}
+                    </label>
+                    {% if data_requests|length > 1 %}
                     <select class="form-control" id="select-email" onchange="displaySelectedText()">
                         {% for data_request in data_requests %}
-                        <option value="{{ forloop.counter0 }}">{{ data_request.organization.name }}</option>
+                        <option value="{{ forloop.counter0 }}">{{ data_request.organization.name }} {% if data_request.organization.accepts_email %}{% trans "(Email)" %}{% else %}{% trans "(Mail)" %}{% endif %}</option>
                         {% endfor %}
                     </select>
+                    {% endif %}
                 </div>
                 <div class="form-group">
                     <div class="alert alert-info">
-                        <strong>{% blocktrans trimmed %}
-                        The displayed email messages will be sent when you click "Create request"
+                        <strong>{% blocktrans count counter=data_requests|length trimmed %}
+                        The displayed message will be created when you continue
+                        {% plural %}
+                        The displayed messages will be created when you continue
                         {% endblocktrans %}</strong>
                     </div>
                     {% for data_request in data_requests %}
-                    <div id="email-body-{{ forloop.counter0 }}">
-                        <pre>{{ data_request.to_email_body }}</pre>
+                    <div id="message-body-{{ forloop.counter0 }}">
+                        <span>{% if data_request.organization.accepts_email %}
+                        <span class="glyphicon glyphicon-cloud"></span> {% blocktrans %}Email request to{% endblocktrans %} <b>{{ data_request.organization.name }}</b></span>
+                        {% else %}
+                        <span class="glyphicon glyphicon-envelope"></span> {% blocktrans %}Mail request to{% endblocktrans %} <b>{{ data_request.organization.name }}</b></span>
+                        {% endif %}
+                        <pre>{% if data_request.organization.accepts_email %}{{ data_request.to_email_body }}{% else %}{{ data_request.to_plain_text }}{% endif %}</pre>
                     </div>
                     {% endfor %}
                 </div>
                 {% bootstrap_form form %}
                 {% bootstrap_form captcha_form %}
-                <input class="btn btn-success" id="create_request" type="submit" value="{% trans 'Create request' %}"/>
+                <input class="btn btn-primary" type="button" onclick="window.history.back()" value="{% trans 'Back' %}">
+                <input class="btn btn-success" id="create_request" type="submit"
+                    value="{% if email_organizations and mail_organizations %}{% trans 'Send and create requests' %}
+                           {% elif email_organizations %}{% trans 'Send requests' %}
+                           {% elif mail_organizations %}{% trans 'Create request PDF' %}{% endif %}"/>
             </form>
         </div>
         <div class="col-md-4">
@@ -66,14 +85,14 @@
 </div>
 <script>
 window.addEventListener("load", function(evt) {
-    $("[id^=email-body]").hide();
-    $("#email-body-0").show();
+    $("[id^=message-body]").hide();
+    $("#message-body-0").show();
 });
 
 function displaySelectedText() {
-    $("[id^=email-body]").hide();
+    $("[id^=message-body]").hide();
     var id = $("#select-email").val();
-    $("#email-body-" + id).show();
+    $("#message-body-" + id).show();
 };
 </script>
 {% endblock %}

--- a/getyourdata/data_request/tests.py
+++ b/getyourdata/data_request/tests.py
@@ -225,15 +225,6 @@ class DataRequestCreationTests(TestCase):
         self.assertContains(response, "Review request")
         self.assertNotContains(response, "Create request")
 
-    def test_pending_mail_request_doesnt_need_to_be_reviewed(self):
-        mail_organization = create_mail_organization(self)
-
-        response = self.client.get(
-            reverse("data_request:request_data", args=(mail_organization.id,)))
-
-        self.assertContains(response, "Create request")
-        self.assertNotContains(response, "Review request")
-
     def test_pending_email_request_displays_email_body_for_request(self):
         email_organization = create_email_organization(self)
 
@@ -245,11 +236,11 @@ class DataRequestCreationTests(TestCase):
              "action": "review"})
 
         self.assertContains(
-            response, "Please review the following email messages")
+            response, "Please review the following message")
         self.assertContains(
-            response, "Email organization</option>")
+            response, "Email organization")
 
-        self.assertContains(response, "Create request")
+        self.assertContains(response, "Send request")
         self.assertNotContains(response, "Review request")
 
 

--- a/getyourdata/data_request/tests.py
+++ b/getyourdata/data_request/tests.py
@@ -276,7 +276,7 @@ class LiveDataRequestCreationTests(LiveServerTestCase):
         self.selenium.find_element_by_id("create_request").click()
 
         self.assertIn(
-            "Please review the following email messages", self.selenium.page_source)
+            "Please review the following message", self.selenium.page_source)
 
         self.selenium.find_element_by_id("create_request").click()
 
@@ -305,6 +305,11 @@ class LiveDataRequestCreationTests(LiveServerTestCase):
 
         field = self.selenium.find_element_by_name("some_number")
         field.send_keys("12345678")
+
+        self.selenium.find_element_by_id("create_request").click()
+
+        self.assertIn(
+            "Please review the following message", self.selenium.page_source)
 
         self.selenium.find_element_by_id("create_request").click()
 

--- a/getyourdata/data_request/views.py
+++ b/getyourdata/data_request/views.py
@@ -59,7 +59,8 @@ def request_data(request, org_ids=None):
     action = request.POST.get("action", None)
 
     if request.method == 'POST':
-        form = DataRequestForm(request.POST or None, organizations=organizations)
+        form = DataRequestForm(
+            request.POST or None, organizations=organizations)
 
         captcha_form = None
 
@@ -84,7 +85,7 @@ def request_data(request, org_ids=None):
                 'org_ids': org_ids,
             })
         elif form.is_valid():
-            if action == "send" or len(email_organizations) == 0:
+            if action == "send":
                 pdf_pages = []
                 email_requests = []
 
@@ -189,9 +190,7 @@ def review_request(request, org_ids, organizations, ignore_captcha=True):
             del captcha_form._errors["captcha"]
 
         if form.is_valid():
-            data_requests = get_data_requests(
-                form, email_organizations, mail_organizations)
-
+            data_requests = get_data_requests(form, organizations)
 
     return render(request, "data_request/request_data_review.html", {
         "form": form,
@@ -203,7 +202,7 @@ def review_request(request, org_ids, organizations, ignore_captcha=True):
     })
 
 
-def get_data_requests(form, email_organizations, mail_organizations):
+def get_data_requests(form, organizations):
     """
     Get a list of every data request
 
@@ -213,7 +212,7 @@ def get_data_requests(form, email_organizations, mail_organizations):
     """
     data_requests = []
 
-    for organization in email_organizations:
+    for organization in organizations:
         data_request = get_data_request(organization, form)
         data_requests.append(data_request)
 

--- a/getyourdata/organization/templates/organization/list.html
+++ b/getyourdata/organization/templates/organization/list.html
@@ -33,15 +33,17 @@
                                     <a href="{% url 'data_request:request_data' organization.id %}">{{ organization.name }}</a>
 
                                     <span class="organization-icon-list pull-right">
-											{% if organization.accepts_mail %}<span title="{% trans "Accepts postal requests" %}" class="glyphicon glyphicon-envelope"></span> {% endif %}
-                                            {% if organization.accepts_email %}<span title="{% trans "Accepts email requests " %}" class="glyphicon glyphicon-cloud"></span>{% endif %}</span>
+										{% if organization.accepts_mail %}<span title="{% trans "Accepts postal requests" %}" class="glyphicon glyphicon-envelope"></span> {% endif %}
+                                        {% if organization.accepts_email %}<span title="{% trans "Accepts email requests " %}" class="glyphicon glyphicon-cloud"></span>{% endif %}
+                                        <a class="btn btn-xs btn-primary" href="{% url 'organization:view_organization' organization.id %}">{% trans "View details" %}</a>
+                                    </span>
                                 </td>
                             </tr>
                             {% endfor %}
                         </tbody>
                     </table>
                     <div>
-                        <input type="submit" class="btn btn-success" id="create-request" name="create_request" value="{% trans "Create request" %}" />
+                        <input type="submit" class="btn btn-success" id="create-request" name="create_request" value="{% trans "Create request with selections" %}" />
                         <span class="pull-right">
                             <a class="pull-right btn btn-primary" href="{% url "organization:new_organization" %}">{% trans "Add organization" %}</a>
                         </span>

--- a/getyourdata/organization/templates/organization/list_js.html
+++ b/getyourdata/organization/templates/organization/list_js.html
@@ -14,13 +14,14 @@ REQUEST_DATA_URL = ORIGIN + "{% url 'data_request:request_data' %}";
 
 // Messages
 MESSAGES = {
-    "create_request": "{% trans "Create request" %}",
+    "create_request": "{% trans "Create request with selections" %}",
     "organizations_selected_none": "{% trans "0 organizations selected." %}",
     "organizations_selected_one": "{% trans "1 organization selected." %}",
     "organizations_selected_plural": "{% trans "{0} organizations selected." %}",
     "mail_request_accepted": "{% trans "Accepts postal requests" %}",
     "email_request_accepted": "{% trans "Accepts email requests" %}",
-    "add_organization": "{% trans "Add organization" %}"
+    "add_organization": "{% trans "Add organization" %}",
+    "view_details": "{% trans "View details" %}"
 };
 
 window.addEventListener("load", function(evt) {
@@ -232,11 +233,12 @@ orgList.View = {
         <tr>
             <td>
                 <input id="org-{{ this.id }}" onclick="orgList.Model.checkOrganization({{ this.id }})" type="checkbox" name="org_ids" value="{{ this.id }}" {{#isOrganizationChecked this.id}}checked{{/isOrganizationChecked}}/>
-                <a href="{{ ../ORIGIN_WITH_LANG_CODE }}organizations/view/{{ this.id }}">{{ this.name }}</a>
+                <a href="{{ ../ORIGIN_WITH_LANG_CODE }}request/new/{{ this.id }}">{{ this.name }}</a>
 
                 <span class="organization-icon-list pull-right">
                     {{#if this.accepts_mail}}<a href="#" data-toggle="tooltip" title="{{ ../msg.mail_request_accepted }}"><span class="glyphicon glyphicon-envelope"></span></a> {{/if}}
                     {{#if this.accepts_email}}<a href="#" data-toggle="tooltip" title="{{ ../msg.email_request_accepted }}"><span class="glyphicon glyphicon-cloud"></span></a> {{/if}}
+                    <a class="btn btn-xs btn-primary" href="{{ ../ORIGIN_WITH_LANG_CODE }}organizations/view/{{ this.id }}">{{ ../msg.view_details }}</a>
                 </span>
             </td>
         </tr>

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -5,6 +5,8 @@ from django.core.urlresolvers import reverse
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 from getyourdata.test import isDjangoTest, isSeleniumTest
 from getyourdata.testcase import LiveServerTestCase
@@ -510,12 +512,18 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
             "%s%s" % (self.live_server_url,
                       reverse("organization:list_organizations")))
 
-        self.selenium.find_element_by_id("page-2").click()
+        element = WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.ID, "page-2"))
+        )
+        element.click()
 
         self.assertIn("Organization 15", self.selenium.page_source)
         self.assertNotIn("Organization 0", self.selenium.page_source)
 
-        self.selenium.find_element_by_id("page-1").click()
+        element = WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.ID, "page-1"))
+        )
+        element.click()
 
         self.assertIn("Organization 0", self.selenium.page_source)
         self.assertNotIn("Organization 15", self.selenium.page_source)


### PR DESCRIPTION
- Add 'back' button to request creation wizard. These utilize browser's 'Back' button, so they might not be completely ideal solution. The same could be done by rendering the form as an invisible form, but that will require more work.
- Streamline request creation steps. Clicking an organization name now leads directly to request creation form.
