### PR TITLE
Minor usability and interface fixes

### DIFF
--- a/getyourdata/data_request/forms.py
+++ b/getyourdata/data_request/forms.py
@@ -70,7 +70,7 @@ class DataRequestForm(forms.Form):
         self.fields["user_email_address"] = forms.EmailField(
             label=_("Receiving email address"),
             help_text=_(
-                "Optional - A copy of your mail requests can be sent to"
+                "Optional - A copy of your mail requests can be sent to "
                 "this email address if filled"),
             required=False,
             widget=forms.TextInput(attrs={"placeholder": ""}))
@@ -83,7 +83,7 @@ class DataRequestForm(forms.Form):
                 label=_("Send a copy of mail requests"),
                 initial=False,
                 help_text=_(
-                    "If checked, a copy of your mail requests will be"
+                    "If checked, a copy of your mail requests will be "
                     "sent to the receiving email address"),
                 required=False)
 

--- a/getyourdata/data_request/templates/data_request/request_data.html
+++ b/getyourdata/data_request/templates/data_request/request_data.html
@@ -37,7 +37,7 @@
                 <input class="btn btn-success" id="create_request" type="submit" name="review" value="{% trans 'Review request' %}"/>
                 <!-- First button on form is considered the default, eg. pressing Enter will invoke the first button in the form
                      Put the "Back" button here as the second button, but move it to the first position using pull-left -->
-                <a class="btn btn-primary first-button" type="button" name="return" value="{% trans 'Back' %}">
+                <input formnovalidate class="btn btn-primary first-button" type="submit" name="return" value="{% trans 'Back' %}">
             </form>
         </div>
         <div class="col-md-4">

--- a/getyourdata/data_request/templates/data_request/request_data.html
+++ b/getyourdata/data_request/templates/data_request/request_data.html
@@ -37,7 +37,7 @@
                 <input class="btn btn-success" id="create_request" type="submit" name="review" value="{% trans 'Review request' %}"/>
                 <!-- First button on form is considered the default, eg. pressing Enter will invoke the first button in the form
                      Put the "Back" button here as the second button, but move it to the first position using pull-left -->
-                <input class="btn btn-primary first-button" type="submit" name="return" value="{% trans 'Back' %}">
+                <a class="btn btn-primary first-button" type="button" name="return" value="{% trans 'Back' %}">
             </form>
         </div>
         <div class="col-md-4">

--- a/getyourdata/home/templates/home/default.html
+++ b/getyourdata/home/templates/home/default.html
@@ -29,21 +29,17 @@
             <div class="well">
                 <h3>How do I make a request?</h3>
                 <hr>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <img class="thumbnail center" src="{% static 'img/home/step1-envelope-icon.png' %}">
                     <h3>1 <small>Choose organization from the list</small></h3>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <img class="thumbnail center" src="{% static 'img/home/step2-person-icon.png' %}">
                     <h3>2 <small>Fill your personal information for the authentication</small></h3>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <img class="thumbnail center" src="{% static 'img/home/step3-data-icon.png' %}">
                     <h3>3 <small>Send request to organization using email or a letter</small></h3>
-                </div>
-                <div class="col-md-3">
-                    <img class="thumbnail center" src="http://placekitten.com/200/200">
-                    <h3>4 <small>Tell us how your request went to help other users</small></h3>
                 </div>
                 <hr>More information about <a href="{% url 'faq' %}">how to request your data</a>
             </div>

--- a/getyourdata/home/templates/home/default.html
+++ b/getyourdata/home/templates/home/default.html
@@ -2,48 +2,10 @@
 {% load staticfiles %}
 
 {% language lang_code %}
-<div class="container">
-    <div class="row">
-        <div class="col-md-6">
-            <div class="page-header">
-                <h1>Get a copy of your own data</h1>
-            </div>
-            You have a right to get copy of the data companies and public sector has about you. GetYourData helps you with making the enquiries.
-            <br/>
-            <br/>
-            <p>
-                <a href="{% url 'organization:list_organizations' %}" class="btn btn-primary btn-lg">
-                    <span class="glyphicon glyphicon-pencil"></span>
-                    Make a request
-                </a>
-            </p>
-        </div>
-        <div class="col-md-6">
-            <br/>
-            <img class="center" src="{% static 'img/home/frontpage-icons.jpg' %}" />
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-12">
-            <br/>
-            <div class="well">
-                <h3>How do I make a request?</h3>
-                <hr>
-                <div class="col-md-4">
-                    <img class="thumbnail center" src="{% static 'img/home/step1-envelope-icon.png' %}">
-                    <h3>1 <small>Choose organization from the list</small></h3>
-                </div>
-                <div class="col-md-4">
-                    <img class="thumbnail center" src="{% static 'img/home/step2-person-icon.png' %}">
-                    <h3>2 <small>Fill your personal information for the authentication</small></h3>
-                </div>
-                <div class="col-md-4">
-                    <img class="thumbnail center" src="{% static 'img/home/step3-data-icon.png' %}">
-                    <h3>3 <small>Send request to organization using email or a letter</small></h3>
-                </div>
-                <hr>More information about <a href="{% url 'faq' %}">how to request your data</a>
-            </div>
-        </div>
-    </div>
-</div>
+
+    {% comment %}
+        this template is basically obsolete as the front page content management is done with
+        admin tool.
+    {% endcomment %}
+
 {% endlanguage %}

--- a/getyourdata/organization/templates/organization/list_js.html
+++ b/getyourdata/organization/templates/organization/list_js.html
@@ -233,7 +233,7 @@ orgList.View = {
         <tr>
             <td>
                 <input id="org-{{ this.id }}" onclick="orgList.Model.checkOrganization({{ this.id }})" type="checkbox" name="org_ids" value="{{ this.id }}" {{#isOrganizationChecked this.id}}checked{{/isOrganizationChecked}}/>
-                <a href="{{ ../ORIGIN_WITH_LANG_CODE }}request/new/{{ this.id }}">{{ this.name }}</a>
+                <a onclick="orgList.Model.checkOrganization({{ this.id }})" href="#">{{ this.name }}</a>
 
                 <span class="organization-icon-list pull-right">
                     <a class="btn btn-xs btn-primary" href="{{ ../ORIGIN_WITH_LANG_CODE }}organizations/view/{{ this.id }}">{{ ../msg.view_details }}</a>

--- a/getyourdata/templates/processbar.html
+++ b/getyourdata/templates/processbar.html
@@ -4,7 +4,6 @@
         <li class="{% if process_step == 1 %}active{% endif %}"><span class="glyphicon glyphicon-envelope"></span>{% trans "Choose organizations" %}</li>
         <li class="{% if process_step == 2 %}active{% endif %}"><span class="glyphicon glyphicon-user"></span>{% trans "Fill in your details" %}</li>
         <li class="{% if process_step == 3 %}active{% endif %}"><span class="glyphicon glyphicon-list-alt"></span>{% trans "Review and send requests" %}</li>
-        <li class="{% if process_step == 4 %}active{% endif %}"><span class="glyphicon glyphicon-comment"></span>{% trans "Give feedback" %}</li>
     </ul>
 
 <!-- end progress bar -->


### PR DESCRIPTION
- Clicking organization name in list now selects/unselects organization instead of leading to the organization's data request creation page.
- Fourth step (give feedback) removed from front page and wizard progress bar
- User can cancel data request creation with "Back" button without browser complaining about form validation
