### PR TITLE
Make remote Selenium tests more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
 - sleep 3 # give xvfb some time to start
 install:
 - pip install -r requirements.txt
-- python dev_manage.py makemigrations flatpages
 - python dev_manage.py migrate
 - python dev_manage.py update_translation_fields
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ python:
 before_install:
 - cd getyourdata
 - sudo ./create_dev_db.bash
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
+- sleep 3 # give xvfb some time to start
 install:
 - pip install -r requirements.txt
 - python dev_manage.py makemigrations flatpages
 - python dev_manage.py migrate
 - python dev_manage.py update_translation_fields
 script:
-- (test -n "$SAUCE_ACCESS_KEY" && coverage run dev_manage.py test_all) || (test -z "$SAUCE_ACCESS_KEY" && coverage run dev_manage.py test)
+- coverage run dev_manage.py test_all
 - codeclimate-test-reporter
 after_success:
 - test $TRAVIS_BRANCH = "master" && export SSHPASS=$DEPLOY_PASS
@@ -24,10 +27,7 @@ addons:
     - sshpass
   code_climate:
     repo_token: 42571cb2de5890d0afd0580da602aa5ceef9b7eb2d3bec7fa78f294e57b01d24
-  sauce_connect:
-    username: "Matoking"
-    access_key:
-      secure: "KJtL0zSSFJr15dAfuIVYhQt9L0i5iU2j/sxD13gSmNPAvMFWph4snPBFlCdjKBhRGEvmK9cTGqpN74V3b+G1INemg5+m/kfpQJ6S0j6JwAC8Pf2XmPAo0vG8VqUyvekhHUxbIBk2ffVn65MSxCvIyqxwsQt7iDHZQompMnbipAAycA/RuTYQ4X6wkM+qutO7sNhVJ2ldYV+a/vqegwgCCKf87LYEqDy/3JFn2besI6YXDKMdmsXQXEXPqF85YOUbz9DMGd6xHQyQECZKBepl+IwGotdxFC2ceInB7WqokEqfnC9f49i4Z9ZuftcU0Ms/9scrkE8AF8Vm8p4Zdhujj5Mbadqndtx/hbngAayI0zG9l3PABAXlHXGO85FSuTA5KeGYpIhT7eMqoqyd5dbtESHZTatT3ITllK3Bx7bKVWl9Une8IqzAlNzA3lDE9Zdxwfmn970oPvfnSq7QjWpYe/S5Nxe0UuFdnJWsI9b5GeeTIh88eGU2nKJYNzVm9zms7k5SvyByXe9yTXW0iidEgj6YYQB6ItZ9TtyqyAYu14Lgrcgk3JpHar3tn0jAiR/wdmVez2vep35bu87zVqGS8hwRTvZhpHTt48o2+rBFJDjFQmFwqVdotMC48qoFQIP7IETb/jEZo+qLiryaf42tPPYMQ6Zkd1hUvE8Y5DKCQbU="
+  firefox: "44.0"
 env:
   global:
   - secure: Z0MZzP8JLezxjxfgJ6aL9uW0+8E5lBZ5zN+PxTqpJOliz/CM0coigvIoI72viX7xTd25BOPndim9nhF28LrDSuMm8VxeIOjgIsqJRkTmVa2tJhHqRTPohD46k4jzkTLBgiw4yncsBpwYYpYx9o3a0V7NpPYBkwu4NrAs/LHEv1UeW2qFNr7EpDKiHJPN4CjUgmyd3dLjky/aFvFqviG97VcZ83pvslwr4qHahV/Y/GwGoWupAqmWIOK3Msf/TSHvb+QY8QjWcES5JZYVU+or6iLk6pZ5e54gZvgIZDb/4WHnZDwvCIInn9CnVfHxuPFamEZJZbrJWZYbL3fM/5o7G6K0iiVH44rQ5eO24J3bt7SbEo6I3pYwL0Z66YxmQaPGPdPjU70Hj9O1yviMrIWf+3jVKzQjzCULNkASpXNVtbwAbRNxaN2u9iJImA21dr6sQfau0MPbsO2zuZGlOPs8dHgFXTMfS3uWqNzTi7/jlIFx/PSwXQqsxe4LEY5lg9qCAE+vIZHFWT4+kb1nA3xsUMrpATC1n9geuu6aMuCfN3LqulcIuAlj2Jj/cZe6ZVy3BK9ssD9y3V0MzvV0A/ESHNhEOJr0Om3xSoytaox6sd02ANu+YUXh18pCIEFyBEK6EAUqTDJE3JywXW1hmBWBp6Bb2N1/A/IzcZiW7tZ9cjc=

--- a/getyourdata/home/templates/home/default.html
+++ b/getyourdata/home/templates/home/default.html
@@ -45,5 +45,5 @@
             </div>
         </div>
     </div>
-</div
+</div>
 {% endlanguage %}

--- a/getyourdata/organization/templates/organization/list.html
+++ b/getyourdata/organization/templates/organization/list.html
@@ -37,9 +37,7 @@
                                 {% for organization in organizations %}
                                     <tr>
                                         <td>
-                                            <input id="org-{{ organization.id }}"
-                                                   onclick="updateOrganizationCheckboxes()" type="checkbox"
-                                                   name="org_ids" value="{{ organization.id }}"
+                                            <input name="org_ids" value="{{ organization.id }}"
                                                    {% if organization.id in org_ids %}checked{% endif %}/>
                                             <a href="{% url 'data_request:request_data' organization.id %}">{{ organization.name }}</a>
                                     <span class="organization-icon-list pull-right">

--- a/getyourdata/organization/templates/organization/list_js.html
+++ b/getyourdata/organization/templates/organization/list_js.html
@@ -164,7 +164,8 @@ orgList.Model = {
             context.pages.push({
                 "page": page,
                 "label": page,
-                "active": context.currentPage === page ? true : false
+                "active": context.currentPage === page ? true : false,
+                "disabled": context.currentPage == page ? true : false
             });
         }
 
@@ -172,7 +173,7 @@ orgList.Model = {
             "page": context.pageCount,
             "last": true,
             "label": "&raquo;",
-            "disabled": context.currentPage === context.pageCount ? true : false
+            "disabled": context.currentPage == context.pageCount ? true : false
         });
     },
 
@@ -239,7 +240,7 @@ orgList.View = {
                 <span class="organization-icon-list pull-right">
                     <a class="btn btn-xs btn-primary" href="{{ ../ORIGIN_WITH_LANG_CODE }}organizations/view/{{ this.id }}">{{ ../msg.view_details }}</a>
                 </span>
-                
+
             </td>
         </tr>
         {{/each}}
@@ -254,7 +255,7 @@ orgList.View = {
 </div>
 <ul class="pagination">
     {{#each pages}}
-    <li class="{{#if this.prev}}prev{{/if}} {{#if this.disabled }}disabled{{/if}} {{# if this.active }}active{{/if}}">
+    <li class="{{#if this.prev}}prev{{/if}} {{# if this.active }}active{{/if}}">
         <a id="page-{{ this.page }}" href="#" onclick="{{#unless this.disabled}}orgList.Controller.loadPage({{this.page}}){{/unless}}">{{{ this.label }}}</a>
     </li>
     {{/each}}

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -449,13 +449,13 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
         ).click()
 
         self.assertIn("1 organization selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.ID, "create-request"))
+            EC.visibility_of_element_located((By.ID, "create-request"))
         ).click()
 
         self.assertIn(
@@ -467,15 +467,17 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
         ).click()
 
         self.assertIn("2 organizations selected", self.selenium.page_source)
 
-        self.selenium.find_element_by_id("create-request").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.visibility_of_element_located((By.ID, "create-request"))
+        ).click()
 
         self.assertIn(
             "Request your data from multiple organizations",
@@ -487,14 +489,14 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.ID, "page-2"))
+            EC.visibility_of_element_located((By.ID, "page-2"))
         ).click()
 
         self.assertIn("Organization 15", self.selenium.page_source)
         self.assertNotIn("Organization 0", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.ID, "page-1"))
+            EC.visibility_of_element_located((By.ID, "page-1"))
         ).click()
 
         self.assertIn("Organization 0", self.selenium.page_source)
@@ -506,35 +508,35 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
         ).click()
         self.assertIn("2 organizations selected", self.selenium.page_source)
 
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.ID, "page-2"))
+            EC.visibility_of_element_located((By.ID, "page-2"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
         ).click()
         self.assertIn("4 organizations selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.ID, "page-3"))
+            EC.visibility_of_element_located((By.ID, "page-3"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
         ).click()
         self.assertIn("6 organizations selected", self.selenium.page_source)
 

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -550,6 +550,11 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                 By.XPATH,
                 "(//a[@id='page-2' and contains(@onclick, 'orgList')])"))
         ).click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.presence_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-2' and @onclick='' and text()='2'])"))
+        )
 
         WebDriverWait(self.selenium, 10).until(
             EC.presence_of_element_located((
@@ -568,6 +573,11 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                 By.XPATH,
                 "(//a[@id='page-3' and contains(@onclick, 'orgList')])"))
         ).click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.presence_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-3' and @onclick='' and text()='3'])"))
+        )
 
         WebDriverWait(self.selenium, 10).until(
             EC.presence_of_element_located((

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -449,7 +449,8 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((
+                By.XPATH, "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
 
         self.assertIn("1 organization selected", self.selenium.page_source)
@@ -467,10 +468,14 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
 
         self.assertIn("2 organizations selected", self.selenium.page_source)
@@ -508,10 +513,14 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
         self.assertIn("2 organizations selected", self.selenium.page_source)
 
@@ -521,10 +530,14 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
         self.assertIn("4 organizations selected", self.selenium.page_source)
 
@@ -533,10 +546,12 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[1]"))
+            EC.visibility_of_element_located((
+                By.XPATH, "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "(//input[@type='checkbox'])[2]"))
+            EC.visibility_of_element_located((
+                By.XPATH, "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
         self.assertIn("6 organizations selected", self.selenium.page_source)
 

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -449,14 +449,14 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH, "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
 
         self.assertIn("1 organization selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//button[@id='create-request' and contains(@onclick, 'orgList')])"))
         ).click()
@@ -470,12 +470,12 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
@@ -483,7 +483,7 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         self.assertIn("2 organizations selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//button[@id='create-request' and contains(@onclick, 'orgList')])"))
         ).click()
@@ -498,30 +498,30 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//a[@id='page-2' and contains(@onclick, 'orgList')])"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
-                "(//a[@id='page-2' and @href='#'])"))
+                "(//a[@id='page-2' and @onclick='' and text()='2'])"))
         )
 
         self.assertIn("Organization 15", self.selenium.page_source)
         self.assertNotIn("Organization 0", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//a[@id='page-1' and contains(@onclick, 'orgList')])"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
-                "(//a[@id='page-1' and @href='#'])"))
+                "(//a[@id='page-1' and @onclick='' and text()='1'])"))
         )
 
         self.assertIn("Organization 0", self.selenium.page_source)
@@ -533,12 +533,12 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
@@ -546,35 +546,35 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
 
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//a[@id='page-2' and contains(@onclick, 'orgList')])"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
         self.assertIn("4 organizations selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH,
                 "(//a[@id='page-3' and contains(@onclick, 'orgList')])"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH, "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[1]"))
         ).click()
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((
+            EC.presence_of_element_located((
                 By.XPATH, "(//input[@type='checkbox' and contains(@onclick, 'orgList')])[2]"))
         ).click()
         self.assertIn("6 organizations selected", self.selenium.page_source)

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -503,6 +503,12 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                 "(//a[@id='page-2' and contains(@onclick, 'orgList')])"))
         ).click()
 
+        WebDriverWait(self.selenium, 10).until(
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-2' and @href='#'])"))
+        )
+
         self.assertIn("Organization 15", self.selenium.page_source)
         self.assertNotIn("Organization 0", self.selenium.page_source)
 
@@ -511,6 +517,12 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                 By.XPATH,
                 "(//a[@id='page-1' and contains(@onclick, 'orgList')])"))
         ).click()
+
+        WebDriverWait(self.selenium, 10).until(
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-1' and @href='#'])"))
+        )
 
         self.assertIn("Organization 0", self.selenium.page_source)
         self.assertNotIn("Organization 15", self.selenium.page_source)

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -456,7 +456,9 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         self.assertIn("1 organization selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.ID, "create-request"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//button[@id='create-request' and contains(@onclick, 'orgList')])"))
         ).click()
 
         self.assertIn(
@@ -481,7 +483,9 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         self.assertIn("2 organizations selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.ID, "create-request"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//button[@id='create-request' and contains(@onclick, 'orgList')])"))
         ).click()
 
         self.assertIn(
@@ -494,14 +498,18 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
                       reverse("organization:list_organizations")))
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.ID, "page-2"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-2' and contains(@onclick, 'orgList')])"))
         ).click()
 
         self.assertIn("Organization 15", self.selenium.page_source)
         self.assertNotIn("Organization 0", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.ID, "page-1"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-1' and contains(@onclick, 'orgList')])"))
         ).click()
 
         self.assertIn("Organization 0", self.selenium.page_source)
@@ -526,7 +534,9 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
 
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.ID, "page-2"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-2' and contains(@onclick, 'orgList')])"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
@@ -542,7 +552,9 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         self.assertIn("4 organizations selected", self.selenium.page_source)
 
         WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.ID, "page-3"))
+            EC.visibility_of_element_located((
+                By.XPATH,
+                "(//a[@id='page-3' and contains(@onclick, 'orgList')])"))
         ).click()
 
         WebDriverWait(self.selenium, 10).until(

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -448,11 +448,15 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
             "%s%s" % (self.live_server_url,
                       reverse("organization:list_organizations")))
 
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[1]").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+        ).click()
+
         self.assertIn("1 organization selected", self.selenium.page_source)
 
-        self.selenium.find_element_by_id("create-request").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.ID, "create-request"))
+        ).click()
 
         self.assertIn(
             "Request your data from Organization 0", self.selenium.page_source)
@@ -462,10 +466,13 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
             "%s%s" % (self.live_server_url,
                       reverse("organization:list_organizations")))
 
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[1]").click()
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[2]").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+        ).click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+        ).click()
+
         self.assertIn("2 organizations selected", self.selenium.page_source)
 
         self.selenium.find_element_by_id("create-request").click()
@@ -479,18 +486,16 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
             "%s%s" % (self.live_server_url,
                       reverse("organization:list_organizations")))
 
-        element = WebDriverWait(self.selenium, 10).until(
+        WebDriverWait(self.selenium, 10).until(
             EC.element_to_be_clickable((By.ID, "page-2"))
-        )
-        element.click()
+        ).click()
 
         self.assertIn("Organization 15", self.selenium.page_source)
         self.assertNotIn("Organization 0", self.selenium.page_source)
 
-        element = WebDriverWait(self.selenium, 10).until(
+        WebDriverWait(self.selenium, 10).until(
             EC.element_to_be_clickable((By.ID, "page-1"))
-        )
-        element.click()
+        ).click()
 
         self.assertIn("Organization 0", self.selenium.page_source)
         self.assertNotIn("Organization 15", self.selenium.page_source)
@@ -500,26 +505,37 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
             "%s%s" % (self.live_server_url,
                       reverse("organization:list_organizations")))
 
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[1]").click()
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[2]").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+        ).click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+        ).click()
         self.assertIn("2 organizations selected", self.selenium.page_source)
 
-        self.selenium.find_element_by_id("page-2").click()
 
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[1]").click()
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[2]").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.ID, "page-2"))
+        ).click()
+
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+        ).click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+        ).click()
         self.assertIn("4 organizations selected", self.selenium.page_source)
 
-        self.selenium.find_element_by_id("page-3").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.ID, "page-3"))
+        ).click()
 
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[1]").click()
-        self.selenium.find_element(
-            By.XPATH, "(//input[@type='checkbox'])[2]").click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[1]"))
+        ).click()
+        WebDriverWait(self.selenium, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "(//input[@type='checkbox'])[2]"))
+        ).click()
         self.assertIn("6 organizations selected", self.selenium.page_source)
 
 


### PR DESCRIPTION
Improve Selenium test reliability by doing two things:
- Run Selenium tests on Travis using xvfb instead of relying on Sauce Labs. On top of avoiding Sauce Labs' random failures, tests running on xvfb appear to catch race conditions more frequently than Sauce Labs.
- Add conditional waits to many of the organization list tests to avoid race conditions between Selenium clicking elements and the DOM changing at the same time.
