### PR TITLE
Usability fixes

### DIFF
--- a/getyourdata/data_request/templates/data_request/request_data_feedback.html
+++ b/getyourdata/data_request/templates/data_request/request_data_feedback.html
@@ -22,7 +22,8 @@
                     You have successfully finished creating and sending a data request!
                     {% plural %}
                     You have successfully finished creating and sending your data requests!
-                    {% endblocktrans %}</p>
+                    {% endblocktrans %}
+                    {% if email_organizations|length > 0 %}{% trans "You should receive a copy of your email requests to your email address shortly." %}{% endif %}</p>
                     <p>{% blocktrans count counter=organizations|length trimmed %}
                     When you have received a reply to your data request, please review your process with the organization below. Your feedback will help the other users!
                     {% plural %}

--- a/getyourdata/data_request/templates/data_request/request_data_feedback.html
+++ b/getyourdata/data_request/templates/data_request/request_data_feedback.html
@@ -32,6 +32,12 @@
                     <p><b><span class="glyphicon glyphicon-bookmark"></span> {% blocktrans %}
                     You can add this page into your bookmarks for later use.
                     {% endblocktrans %}</b></p>
+                    {% if pdf_data %}
+                    <p>
+                        <a class="btn btn-primary btn-sm" href="data:application/pdf;base64,{{ pdf_data }}"
+                           target="_blank" download="request.pdf">{% trans "Redownload PDF" %}</a>
+                    </p>
+                    {% endif %}
                 </div>
                 <table class="table table-striped">
                     <tbody>

--- a/getyourdata/data_request/templates/data_request/request_data_sent.html
+++ b/getyourdata/data_request/templates/data_request/request_data_sent.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load extra_tags %}
 
 {% block content %}
     <div class="container">
@@ -25,8 +26,7 @@
         <div class="row">
             {% if mail_organizations %}
                 <div class="col-md-6">
-                    <h3><span
-                            class="glyphicon glyphicon-info-sign"></span> {% trans "Print mail requests" %}</h3>
+                    <h3><span class="glyphicon glyphicon-info-sign"></span> {% trans "Print mail requests" %}</h3>
                     <div class="alert alert-warning">
                         <strong>
                             {% blocktrans count counter=mail_organizations|length trimmed %}
@@ -34,7 +34,8 @@
                                 {% plural %}
                                 {{ counter }} requests need to be printed.
                             {% endblocktrans %}
-                        </strong><br>
+                        </strong>
+                        <br>
                         <p>{% blocktrans trimmed %}
                             The following organizations require that data requests are sent by mail:
                         {% endblocktrans %}</p>
@@ -46,14 +47,26 @@
                         <br>
                         <p>{% trans "You can send data requests to the listed organizations by mail. The following document contains the required pages:" %}</p>
                         <br>
-                        <a class="btn btn-xl btn-success" href="data:application/pdf;base64,{{ pdf_data }}"
-                           target="_blank" download="request.pdf"><span
-                                class="glyphicon glyphicon-download-alt"></span> {% trans "Download PDF" %}</a>
+                        <form id="feedback_form" method="post" action="{% url 'data_request:give_feedback' org_ids %}">
+                            {% csrf_token %}
+                            {% bootstrap_form form|hide_form %}
+                            <input id="submit_form" style="display: none;" type="submit" value="submit"/>
+                            <a class="btn btn-xl btn-success" href="data:application/pdf;base64,{{ pdf_data }}"
+                               target="_blank" download="request.pdf" onclick="$('#submit_form').click()"><span
+                                    class="glyphicon glyphicon-download-alt"></span> {% trans "Download PDF" %}</a>
+                        </form>
                         <br>
                         {% if mail_request_copy_sent %}
                         <p>{% trans "A copy of the PDF has been sent to your email address." %}</p>
                         {% endif %}
                     </div>
+                    <a class="btn btn-primary" id="next_step_button">{% trans "Finish" %}</a>
+                    <script>
+                    // For browsers without JavaScript, leave the button above visible so that the users
+                    // can continue to the last step
+                    // For browsers with JavaScript, hide the above button on page load
+                    document.getElementById("next_step_button").style["display"] = "none";
+                    </script>
                 </div>
             {% endif %}
             {% if email_organizations %}
@@ -71,17 +84,6 @@
                     </div>
                 </div>
             {% endif %}
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <a class="btn btn-success" href="{% url "data_request:give_feedback" org_ids %}">
-                    <span class="glyphicon glyphicon-star"></span> {% trans "Give feedback" %}
-                </a>
-                <b>{% trans "or" %}</b>
-                <a class="btn btn-info" href="{% url "home" %}">
-                    <span class="glyphicon glyphicon-home"></span> {% trans "Return to the home page" %}
-                </a>
-            </div>
         </div>
     </div>
 {% endblock %}

--- a/getyourdata/data_request/tests.py
+++ b/getyourdata/data_request/tests.py
@@ -152,10 +152,7 @@ class DataRequestCreationTests(TestCase):
             )
 
         # All requests were email requests
-        self.assertContains(response, "All done!")
-
-        self.assertContains(
-            response, "Requests were sent to the following organizations")
+        self.assertContains(response, "You have successfully finished")
 
         self.assertContains(response, "Organization")
 
@@ -329,8 +326,8 @@ class LiveDataRequestCreationTests(LiveServerTestCase):
 
         self.selenium.find_element_by_id("create_request").click()
 
-        self.assertIn("All done!", self.selenium.page_source)
-        self.assertIn("Email requests sent!", self.selenium.page_source)
+        self.assertIn("You have successfully finished", self.selenium.page_source)
+        self.assertIn("You should receive a copy of your email requests", self.selenium.page_source)
 
     def test_selenium_mail_request_can_be_created_successfully(self):
         self.organization = Organization.objects.create(

--- a/getyourdata/data_request/views.py
+++ b/getyourdata/data_request/views.py
@@ -267,6 +267,7 @@ def give_feedback(request, org_ids):
 
     return render(request, "data_request/request_data_feedback.html", {
         "org_ids": org_ids,
+        "email_organizations": email_organizations,
         "organizations": organizations,
         "pdf_data": pdf_data,
     })

--- a/getyourdata/feedback/forms.py
+++ b/getyourdata/feedback/forms.py
@@ -7,8 +7,8 @@ from feedback.models import ServiceFeedback
 class NewFeedbackForm(forms.ModelForm):
     content = forms.CharField(
         error_messages={
-        'required':_('Message is required'),
-        'max_length':_('Maximum allowed length is 4096 characters')
+            'required': _('Message is required'),
+            'max_length': _('Maximum allowed length is 4096 characters')
         },
         label=_('Message'),
         max_length=4096,

--- a/getyourdata/feedback/templates/feedback.html
+++ b/getyourdata/feedback/templates/feedback.html
@@ -1,31 +1,22 @@
 {% load i18n %}
 {% load bootstrap3 %}
-<div class="container">
-    <div class="row">
-        <div class="col-md-12">
-            <br>
-            <div class="panel panel-warning">
-                <div class="panel-body">
-                    <p>
-                        {% blocktrans %}Feedback regarding this service?{% endblocktrans %}
-                    </p>
-                    <form role="form" action="{% url 'feedback:send_feedback' %}" method="post">
-                        {% csrf_token %}
-                        <div class="form-group">
-                            {% if feedback_form.content.errors %}
-                            <ul>
-                                {% for error in feedback_form.content.errors %}
-                                <li>{{ error }}</li>
-                                {% endfor %}
-                            </ul>
-                            {% endif %}
-                            <textarea style="resize:none" class="form-control" cols="40" rows="5" id="id_content" name="content" placeholder="{{ feedback_form.content.label }}" required="required" rows="10" title>{% if feedback_form.content.value %}{{ feedback_form.content.value }}{% endif %}</textarea>
-                        </div>
-                        {# {% bootstrap_form captcha_form %} #}
-                        <input class="btn btn-default" type="submit" value="{% trans 'Leave feedback' %}" />
-                    </form>
-                </div>
-            </div>
+<div class="container-fluid">
+    <p>
+        {% blocktrans %}Feedback regarding this service?{% endblocktrans %}
+    </p>
+    <form role="form" action="{% url 'feedback:send_feedback' %}" method="post">
+        {% csrf_token %}
+        <div class="form-group">
+            {% if feedback_form.content.errors %}
+            <ul>
+                {% for error in feedback_form.content.errors %}
+                <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+            <textarea class="form-control feedback-textarea" id="id_content" name="content" placeholder="{{ feedback_form.content.label }}" required="required" cols="100"  rows="7" title>{% if feedback_form.content.value %}{{ feedback_form.content.value }}{% endif %}</textarea>
         </div>
-    </div>
+        {# {% bootstrap_form captcha_form %} #}
+        <input class="btn btn-default" type="submit" value="{% trans 'Leave feedback' %}" />
+    </form>
 </div>

--- a/getyourdata/feedback/templates/feedback.html
+++ b/getyourdata/feedback/templates/feedback.html
@@ -1,10 +1,11 @@
 {% load i18n %}
 {% load bootstrap3 %}
+{% load staticfiles %}
 <div class="container-fluid">
     <p>
         {% blocktrans %}Feedback regarding this service?{% endblocktrans %}
     </p>
-    <form role="form" action="{% url 'feedback:send_feedback' %}" method="post">
+    <form id="send_feedback_form" role="form" action="{% url 'feedback:send_feedback' %}" method="post">
         {% csrf_token %}
         <div class="form-group">
             {% if feedback_form.content.errors %}
@@ -17,6 +18,10 @@
             <textarea class="form-control feedback-textarea" id="id_content" name="content" placeholder="{{ feedback_form.content.label }}" required="required" cols="100"  rows="7" title>{% if feedback_form.content.value %}{{ feedback_form.content.value }}{% endif %}</textarea>
         </div>
         {# {% bootstrap_form captcha_form %} #}
-        <input class="btn btn-default" type="submit" value="{% trans 'Leave feedback' %}" />
+        <input id="send_feedback" class="btn btn-default" type="submit" value="{% trans 'Leave feedback' %}" />
     </form>
+    <script>
+    var SEND_FEEDBACK_URL = "{% url "feedback:send_feedback_json" %}";
+    </script>
+    <script src="{% static "js/getyourdata-feedback.js" %}"></script>
 </div>

--- a/getyourdata/feedback/tests.py
+++ b/getyourdata/feedback/tests.py
@@ -2,7 +2,12 @@
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
-from getyourdata.test import isDjangoTest
+from getyourdata.test import isDjangoTest, isSeleniumTest
+from getyourdata.testcase import LiveServerTestCase
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 from feedback.models import ServiceFeedback
 
@@ -39,3 +44,37 @@ class FeedbackTests(TestCase):
         self.assertEquals(
             list(response.context['messages'])[0].message,
             "Message: Maximum allowed length is 4096 characters")
+
+
+@isSeleniumTest()
+class FeedbackLiveTests(LiveServerTestCase):
+    def test_user_can_send_feedback(self):
+        self.selenium.get(
+            "%s" % (self.live_server_url))
+
+        self.selenium.find_element_by_id("give_feedback_nav_link").click()
+
+        WebDriverWait(self.selenium, 10).until(
+            EC.presence_of_element_located((
+                By.XPATH,
+                "(//input[@id='send_feedback' and @disabled='disabled'])"))
+        )
+
+        self.selenium.find_element_by_id(
+            "id_content").send_keys("This is feedback.")
+
+        WebDriverWait(self.selenium, 10).until(
+            EC.presence_of_element_located((
+                By.XPATH,
+                "(//input[@id='send_feedback' and not(contains(@disabled, 'disabled'))])"))
+        )
+
+        self.selenium.find_element_by_id("send_feedback").click()
+
+        WebDriverWait(self.selenium, 10).until(
+            EC.presence_of_element_located((
+                By.XPATH,
+                "(//form[@id='send_feedback_form']/div[@class='alert alert-success'])"))
+        )
+
+        self.assertIn("Thank you for your feedback!", self.selenium.page_source)

--- a/getyourdata/feedback/urls.py
+++ b/getyourdata/feedback/urls.py
@@ -5,5 +5,5 @@ from feedback import views as feedback_views
 
 urlpatterns = [
     url(r'^send/$', feedback_views.send_feedback, name='send_feedback'),
+    url(r'^send_json/$', feedback_views.send_feedback_json, name='send_feedback_json'),
 ]
-

--- a/getyourdata/feedback/views.py
+++ b/getyourdata/feedback/views.py
@@ -2,17 +2,23 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from django.shortcuts import redirect
+from django.http import HttpResponse
 
 from feedback.forms import NewFeedbackForm
 
+import json
+
 
 def send_feedback(request):
+    """
+    Send feedback and redirect to home
+    """
     if request.method == "POST":
         form = NewFeedbackForm(request.POST)
         form_valid = form.is_valid()
 
         if form_valid:
-            feedback = form.save()
+            form.save()
             messages.success(request, _('Thank you for your feedback!'))
         else:
             request.session['feedback_content'] = request.POST.get('content')
@@ -22,3 +28,28 @@ def send_feedback(request):
                     form['content'].label, error))
 
     return redirect(reverse('home'))
+
+
+def send_feedback_json(request):
+    """
+    Send feedback and return a JSON reply
+    """
+    response = {"status": "error"}
+
+    if request.method == "POST":
+        form = NewFeedbackForm(request.POST)
+
+        if form.is_valid():
+            form.save()
+            response["status"] = "success"
+            response["message"] = _("Thank you for your feedback!")
+        else:
+            response["status"] = "error"
+            response["message"] = ""
+
+            for error, message in form.errors.iteritems():
+                response["message"] += "%s" % message
+    else:
+        response["message"] = "This command requires HTTP POST to be used"
+
+    return HttpResponse(json.dumps(response))

--- a/getyourdata/home/templates/home/default.html
+++ b/getyourdata/home/templates/home/default.html
@@ -1,28 +1,57 @@
-<div class="container content-area">
-    <div class="row">
-        <div class="col-md-5"><img class="center" src="/static/img/home/frontpage-icons.jpg" /></div>
-        <div class="col-md-7">
-            <div class="well">
-                <div class="row">
-                    <div class="col-md-12">
-                        <h3>Get a copy of your own data</h3>
-                        <hr/> You have a right to get copy of the data companies and public sector has about you. GetYourData helps you with making the enquiries.
+{% load i18n %}
+{% load staticfiles %}
+
+{% language lang_code %}
+
+    {% comment %}
+
+        NOTE:
+
+        This template is only used when initializing the database during set-up of a new site.
+        All modifications to the content from that point onwards shall be done using the CMS
+        tool found in admin/ section of the site.
+
+    {% endcomment %}
+
+    <div class="container content-area">
+        <div class="row">
+            <div class="col-md-5">
+                <img class="center" src="{% static 'img/home/frontpage-icons.jpg' %}"/>
+            </div>
+            <div class="col-md-7">
+                <div class="well">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <h3>Get a copy of your own data</h3>
+                            <hr/>
+                            You have a right to get copy of the data companies and public sector has about you.
+                            GetYourData helps you with making the enquiries.
+                        </div>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-4">
-                        <a href="/en/organizations/"><img class="thumbnail left" src="/static/img/home/step1-envelope-icon.png" /></a>
-                        <h3>1 <small>Choose organization from the list</small></h3>
-                    </div>
-                    <div class="col-md-4"><img class="thumbnail left" src="/static/img/home/step2-person-icon.png" />
-                        <h3>2 <small>Fill your personal information for the authentication</small></h3>
-                    </div>
-                    <div class="col-md-4"><img class="thumbnail left" src="/static/img/home/step3-data-icon.png" />
-                        <h3>3 <small>Send request to organization using email or a letter</small></h3>
+                    <div class="row">
+                        <div class="col-md-4">
+                            <a href="{% url 'organization:list_organizations' %}"><img class="thumbnail left"
+                                                                                       src="{% static 'img/home/step1-envelope-icon.png' %}"/></a>
+                            <h3>1
+                                <small>Choose organization from the list</small>
+                            </h3>
+                        </div>
+                        <div class="col-md-4"><img class="thumbnail left"
+                                                   src="{% static 'img/home/step2-person-icon.png' %}"/>
+                            <h3>2
+                                <small>Fill your personal information for the authentication</small>
+                            </h3>
+                        </div>
+                        <div class="col-md-4"><img class="thumbnail left"
+                                                   src="{% static 'img/home/step3-data-icon.png' %}"/>
+                            <h3>3
+                                <small>Send request to organization using email or a letter</small>
+                            </h3>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
+
 {% endlanguage %}

--- a/getyourdata/home/templates/home/default.html
+++ b/getyourdata/home/templates/home/default.html
@@ -1,47 +1,26 @@
-{% load i18n %}
-{% load staticfiles %}
-
-{% language lang_code %}
-<div class="container">
+<div class="container content-area">
     <div class="row">
-        <div class="col-md-6">
-            <div class="page-header">
-                <h1>Get a copy of your own data</h1>
-            </div>
-            You have a right to get copy of the data companies and public sector has about you. GetYourData helps you with making the enquiries.
-            <br/>
-            <br/>
-            <p>
-                <a href="{% url 'organization:list_organizations' %}" class="btn btn-primary btn-lg">
-                    <span class="glyphicon glyphicon-pencil"></span>
-                    Make a request
-                </a>
-            </p>
-        </div>
-        <div class="col-md-6">
-            <br/>
-            <img class="center" src="{% static 'img/home/frontpage-icons.jpg' %}" />
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-12">
-            <br/>
+        <div class="col-md-5"><img class="center" src="/static/img/home/frontpage-icons.jpg" /></div>
+        <div class="col-md-7">
             <div class="well">
-                <h3>How do I make a request?</h3>
-                <hr>
-                <div class="col-md-4">
-                    <img class="thumbnail center" src="{% static 'img/home/step1-envelope-icon.png' %}">
-                    <h3>1 <small>Choose organization from the list</small></h3>
+                <div class="row">
+                    <div class="col-md-12">
+                        <h3>Get a copy of your own data</h3>
+                        <hr/> You have a right to get copy of the data companies and public sector has about you. GetYourData helps you with making the enquiries.
+                    </div>
                 </div>
-                <div class="col-md-4">
-                    <img class="thumbnail center" src="{% static 'img/home/step2-person-icon.png' %}">
-                    <h3>2 <small>Fill your personal information for the authentication</small></h3>
+                <div class="row">
+                    <div class="col-md-4">
+                        <a href="/en/organizations/"><img class="thumbnail left" src="/static/img/home/step1-envelope-icon.png" /></a>
+                        <h3>1 <small>Choose organization from the list</small></h3>
+                    </div>
+                    <div class="col-md-4"><img class="thumbnail left" src="/static/img/home/step2-person-icon.png" />
+                        <h3>2 <small>Fill your personal information for the authentication</small></h3>
+                    </div>
+                    <div class="col-md-4"><img class="thumbnail left" src="/static/img/home/step3-data-icon.png" />
+                        <h3>3 <small>Send request to organization using email or a letter</small></h3>
+                    </div>
                 </div>
-                <div class="col-md-4">
-                    <img class="thumbnail center" src="{% static 'img/home/step3-data-icon.png' %}">
-                    <h3>3 <small>Send request to organization using email or a letter</small></h3>
-                </div>
-                <hr>More information about <a href="{% url 'faq' %}">how to request your data</a>
             </div>
         </div>
     </div>

--- a/getyourdata/organization/templates/organization/list.html
+++ b/getyourdata/organization/templates/organization/list.html
@@ -55,7 +55,7 @@
             {% else %}
             <p>{% trans "No organizations yet." %}</p>
             <div>
-                <a class="btn btn-primary" href="{% url "organization:new_organization " %}">{% trans "Add organization" %}</a>
+                <a class="btn btn-primary" href="{% url "organization:new_organization" %}">{% trans "Add organization" %}</a>
             </div>
             {% endif %} {% include "organization/list_js.html" %}
         </div>

--- a/getyourdata/organization/templates/organization/list.html
+++ b/getyourdata/organization/templates/organization/list.html
@@ -1,74 +1,64 @@
-{% extends 'base.html' %}
-{% load i18n %}
-{% load bootstrap3 %}
+{% extends 'base.html' %} {% load i18n %} {% load bootstrap3 %} {% block content %}
+<div class="container">
 
-{% block content %}
-    <div class="container">
-
-        {% if organizations %}
-            <div class="row">
-                <div class="col-md-12">
-                    <div>
-                        {% include "processbar.html" with process_step=1 %}
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-
-        <div class="row">
-            <div class="col-md-12">
-
-                <div class="page-header">
-                    {# Translators: On the "list organizations" view #}
-                    <h1>{% trans "Organizations" %}</h1>
-                </div>
-                {% if organizations %}
-                    <div>
-                        {% blocktrans trimmed %}
-                            Choose the organizations you want to get your data from and click the Create Request button.
-                        {% endblocktrans %}
-                    </div>
-                    <div id="organization-list">
-                        <form action="{% url 'organization:list_organizations' %}" method="post">
-                            {% csrf_token %}
-                            <input type="hidden" name="prev_org_ids" value="{{ org_ids }}"/>
-                            <table class="table table-striped">
-                                <tbody>
-                                {% for organization in organizations %}
-                                    <tr>
-                                        <td>
-                                            <input name="org_ids" value="{{ organization.id }}"
-                                                   {% if organization.id in org_ids %}checked{% endif %}/>
-                                            <a href="{% url 'data_request:request_data' organization.id %}">{{ organization.name }}</a>
-                                    <span class="organization-icon-list pull-right">
-                                        <a class="btn btn-xs btn-primary"
-                                           href="{% url 'organization:view_organization' organization.id %}">{% trans "View details" %}</a>
-                                    </span>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                                </tbody>
-                            </table>
-                            <div>
-                                <input type="submit" class="btn btn-success" id="create-request" name="create_request"
-                                       value="{% trans "Create request with selections" %}"/>
-                        <span class="pull-right">
-                            <a class="pull-right btn btn-primary"
-                               href="{% url "organization:new_organization" %}">{% trans "Add organization" %}</a>
-                        </span>
-                            </div>
-                        </form>
-                        {% bootstrap_pagination organizations url=pag_url %}
-                    </div>
-                {% else %}
-                    <p>{% trans "No organizations yet." %}</p>
-                    <div>
-                        <a class="btn btn-primary"
-                           href="{% url "organization:new_organization" %}">{% trans "Add organization" %}</a>
-                    </div>
-                {% endif %}
-                {% include "organization/list_js.html" %}
+    {% if organizations %}
+    <div class="row">
+        <div class="col-md-12">
+            <div>
+                {% include "processbar.html" with process_step=1 %}
             </div>
         </div>
     </div>
+    {% endif %}
+
+    <div class="row">
+        <div class="col-md-12">
+
+            <div class="page-header">
+                {# Translators: On the "list organizations" view #}
+                <h1>{% trans "Organizations" %}</h1>
+            </div>
+            {% if organizations %}
+            <div>
+                {% blocktrans trimmed %} Choose the organizations you want to get your data from and click the Create Request button. {% endblocktrans %}
+            </div>
+            <div id="organization-list">
+                <form action="{% url 'organization:list_organizations' %}" method="post">
+                    {% csrf_token %}
+                    <input type="hidden" name="prev_org_ids" value="{{ org_ids }}" />
+                    <table class="table table-striped">
+                        <tbody>
+                            {% for organization in organizations %}
+                            <tr>
+                                <td>
+                                    <input id="org-{{ organization.id }}" onclick="updateOrganizationCheckboxes()" type="checkbox" name="org_ids" value="{{ organization.id }}" {% if organization.id in org_ids %}checked{% endif %}/>
+                                    <a href="{% url 'data_request:request_data' organization.id %}">{{ organization.name }}</a>
+                                    <span class="organization-icon-list pull-right">
+                                    <a class="btn btn-xs btn-primary"
+                                       href="{% url 'organization:view_organization' organization.id %}">{% trans "View details" %}</a>
+                                </span>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    <div>
+                        <input type="submit" class="btn btn-success" id="create-request" name="create_request" value="{% trans " Create request with selections " %}"/>
+                        <span class="pull-right">
+                        <a class="pull-right btn btn-primary"
+                           href="{% url "organization:new_organization" %}">{% trans "Add organization" %}</a>
+                    </span>
+                    </div>
+                </form>
+                {% bootstrap_pagination organizations url=pag_url %}
+            </div>
+            {% else %}
+            <p>{% trans "No organizations yet." %}</p>
+            <div>
+                <a class="btn btn-primary" href="{% url " organization:new_organization " %}">{% trans "Add organization" %}</a>
+            </div>
+            {% endif %} {% include "organization/list_js.html" %}
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/getyourdata/organization/templates/organization/list.html
+++ b/getyourdata/organization/templates/organization/list.html
@@ -55,7 +55,7 @@
             {% else %}
             <p>{% trans "No organizations yet." %}</p>
             <div>
-                <a class="btn btn-primary" href="{% url " organization:new_organization " %}">{% trans "Add organization" %}</a>
+                <a class="btn btn-primary" href="{% url "organization:new_organization " %}">{% trans "Add organization" %}</a>
             </div>
             {% endif %} {% include "organization/list_js.html" %}
         </div>

--- a/getyourdata/organization/templates/organization/view.html
+++ b/getyourdata/organization/templates/organization/view.html
@@ -98,7 +98,6 @@
 			{% endblocktrans %}</p>
 			{% endif %}
             <hr>
-
             <div class="panel panel-default">
                 <div class="panel-heading"><span class="glyphicon glyphicon-user"></span> {% trans "Received feedback" %}{% if comments %}<span class="pull-right">{% trans 'Average rating' %} {{ organization.average_rating }}/5</span>{% endif %}</div>
                 <div class="panel-body">
@@ -107,7 +106,6 @@
                         <tbody>
                         {% for comment in comments %}
                             <tr>
-
                                 <td class="col-md-9">{{ comment.message }}</td>
                                 <td class="text-right col-md-3">
                                     <span class="small">{{ comment.created_on|date:"j.n.Y H:i" }}</span>

--- a/getyourdata/static/css/getyourdata.css
+++ b/getyourdata/static/css/getyourdata.css
@@ -119,4 +119,6 @@ img.center {
     color: white;
 }
 
-
+.feedback-textarea {
+    width: 250px;
+}

--- a/getyourdata/static/js/getyourdata-feedback.js
+++ b/getyourdata/static/js/getyourdata-feedback.js
@@ -1,0 +1,43 @@
+window.addEventListener("load", function(evt) {
+    // Disable "Leave feedback" if text area is empty
+    $("#send_feedback").attr('disabled', true);
+
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!this.crossDomain) {
+                xhr.setRequestHeader("X-CSRFToken", $("input[name='csrfmiddlewaretoken']").val());
+            }
+        }
+    })
+
+    $("#id_content").bind('input propertychange', function(evt) {
+        if ($("#id_content").val() == "") {
+            $("#send_feedback").attr('disabled', true);
+        } else {
+            $("#send_feedback").attr('disabled', false);
+        }
+    });
+
+    // Send feedback using AJAX
+    $("#send_feedback").attr("type", "button");
+    $("#send_feedback").click(function() {
+        var data = {
+            "content": $("#id_content").val()
+        }
+
+        $.post(SEND_FEEDBACK_URL, data, function(data) {
+            data = JSON.parse(data);
+
+            if (data["status"] === "success") {
+                $("#send_feedback").hide();
+                $("#id_content").hide();
+                $("#send_feedback").before("<div class='alert alert-success'>"
+                    + data["message"] + "</div>");
+            } else {
+                $("#send_feedback_error").remove();
+                $("#send_feedback").before("<div id='send_feedback_error' class='alert alert-danger'>"
+                    + data["message"] + "</div>");
+            }
+        });
+    })
+});

--- a/getyourdata/templates/base.html
+++ b/getyourdata/templates/base.html
@@ -30,8 +30,6 @@
         {% block content %}
         {% endblock content %}
 
-        {% include 'feedback.html' %}
-
         {% include "footer.html" %}
 
         {# SCRIPTS #}

--- a/getyourdata/templates/navbar.html
+++ b/getyourdata/templates/navbar.html
@@ -15,7 +15,7 @@
 			<ul class="pull-left nav navbar-nav">
 				{# Quick feedback #}
 				<li class="dropdown">
-					<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+					<a id="give_feedback_nav_link" href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
 						{% trans "Give feedback" %} <span class="caret"></span>
 					</a>
 					<ul class="dropdown-menu">

--- a/getyourdata/templates/navbar.html
+++ b/getyourdata/templates/navbar.html
@@ -12,26 +12,31 @@
 		        <span class="icon-bar"></span>
 		      </button>
             <a class="navbar-brand" href="{% url 'home' %}">GetYourData.org</a>
+			<ul class="pull-left nav navbar-nav">
+				{# Quick feedback #}
+				<li class="dropdown">
+					<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+						{% trans "Give feedback" %} <span class="caret"></span>
+					</a>
+					<ul class="dropdown-menu">
+						{% include 'feedback.html' %}
+					</ul>
+				</li>
+			</ul>
         </div>
 	    <div class="collapse navbar-collapse" id="main-navbar">
 	    	<ul class="pull-right nav navbar-nav">
 				{# Translators: Navbar link #}
-
 				{% get_current_language as current_language %}
-
 				{% get_flatpages as flatpages %}
 
 				{% for page in flatpages %}
 			        <li><a href="/{{ current_language }}{{ page.url }}">{{ page.title }}</a></li>
 			    {% endfor %}
-
 		        <li><a href="{% url 'organization:list_organizations' %}">{% trans "Organizations" %}</a></li>
-
                 <li><a href="{% url 'faq' %}">{% trans "FAQ" %}</a></li>
-
 		        {# Language selection #}
 		        <li class="dropdown">
-
 					{% get_language_info for current_language as current_lang_info %}
 					<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
 						{{ current_lang_info.name_translated }} <span class="caret"></span>


### PR DESCRIPTION
- Move site-wide feedback form under its own dropdown in the navbar. The feedback form doesn't take up screen estate unless opened by the user.
  - Feedback form also uses AJAX when available, meaning user isn't redirected from the current page if he gives feedback.
- Feedback form text area can be resized by user, which would be useful if the user is writing a long text.
- User is redirected directly into "thanks, please provide feedback page" if only email requests were created.
- Allow user to redownload PDF on the last page. Because the browser can't determine whether the user actually downloaded the PDF (user clicked "Download PDF", then saved the file to disk) or accidentally or purposefully cancelled the download (user clicked "Download PDF", then accidentally cancelled the operation).
