### PR TITLE
Getting titles correct

### DIFF
--- a/getyourdata/data_request/templates/data_request/request_data.html
+++ b/getyourdata/data_request/templates/data_request/request_data.html
@@ -17,11 +17,7 @@
     <div class="row">
         <div class="col-md-12">
             <div class="page-header">
-                {% if organizations|length == 1 %}
-                    <h1>{% trans 'Request your data from' %} {{ organizations.0.name }}</h1>
-                {% else %}
-                    <h1>{% trans 'Request your data from multiple organizations' %}</h1>
-                {% endif %}
+                <h1>{% trans 'Fill in your details' %}</h1>
             </div>
         </div>
     </div>

--- a/getyourdata/data_request/tests.py
+++ b/getyourdata/data_request/tests.py
@@ -89,7 +89,7 @@ class DataRequestCreationTests(TestCase):
 
         self.assertContains(response, "Some number")
         self.assertContains(response, "Other thing")
-        self.assertContains(response, "Request your data from Organization")
+        self.assertContains(response, "Fill in your details")
 
     def test_data_request_form_with_multiple_organizations_is_correct(self):
         response = self.client.get(
@@ -100,7 +100,6 @@ class DataRequestCreationTests(TestCase):
         self.assertContains(response, "Some number")
         self.assertContains(response, "Other thing")
         self.assertContains(response, "Oddest thing")
-        self.assertContains(response, "Request your data from multiple organizations")
 
     def test_data_request_is_created(self):
         self.client.post(

--- a/getyourdata/organization/templates/organization/list.html
+++ b/getyourdata/organization/templates/organization/list.html
@@ -20,7 +20,7 @@
 
             <div class="page-header">
                 {# Translators: On the "list organizations" view #}
-                <h1>{% trans "Organizations" %}</h1>
+                <h1>{% trans "Choose organizations" %}</h1>
             </div>
             {% if organizations %}
             <div>

--- a/getyourdata/organization/tests.py
+++ b/getyourdata/organization/tests.py
@@ -512,7 +512,7 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         ).click()
 
         self.assertIn(
-            "Request your data from Organization 0", self.selenium.page_source)
+            "Fill in your details", self.selenium.page_source)
 
     def test_select_multiple_organizations_for_request(self):
         self.selenium.get(
@@ -539,7 +539,7 @@ class OrganizationListJavascriptTests(LiveServerTestCase):
         ).click()
 
         self.assertIn(
-            "Request your data from multiple organizations",
+            "Fill in your details",
             self.selenium.page_source)
 
     def test_can_change_page_to_display_different_organizations(self):


### PR DESCRIPTION
This pull request is meant to address some title naming related consistency issues that client would like to see fixed. There might be some others that still need addressing though! 

Current title changes:
-Organizations --> Choose organizations
-"Request your data from:" {organization name }-->  Fill in your details (this is used for both singular and plural forms)
